### PR TITLE
Chore: Create python black ci-pipeline

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -1,0 +1,24 @@
+name: CI Pipeline
+
+on: [push, pull_request]
+
+jobs:
+  lint_and_format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install black
+
+    - name: Run Black
+      run: black --check .


### PR DESCRIPTION
### 제목
Ci-pipeline 생성

### 설명
ubuntu-latest, python 3.11.8 환경에서 모든 .py 파일에 black을 적용시켜 .py 파일들이 적용이 안된채로 PR이 되었다면 승인이 되지 못하도록 만들었습니다.

### 변경 사항
./.github/workflows 디렉토리를 생성 후 그안에 ci-pipeline.yaml 파일을 만들었습니다.