### PR TITLE
Feat: 접근 가능한 모든 DB들의 정보를 이용한 Text2SQL

### DIFF
--- a/langgraph_/faiss_init.py
+++ b/langgraph_/faiss_init.py
@@ -1,0 +1,167 @@
+import pandas as pd
+import os
+from typing import List, Dict, Tuple
+from langchain_core.vectorstores import VectorStore
+from langchain_community.vectorstores import FAISS
+from langchain_openai import OpenAIEmbeddings
+
+from sqlalchemy import create_engine, inspect, MetaData
+from dotenv import load_dotenv
+from sqlalchemy.schema import CreateTable
+
+
+def get_db_names(engine) -> List[str]:
+    db_names_query = """
+    SELECT 
+    DISTINCT
+        TABLE_SCHEMA AS db
+    FROM TABLES
+    WHERE TABLE_SCHEMA NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema');
+    """
+
+    print("접근 가능한 모든 데이터베이스를 가져오는 중...")
+    db_names_df = pd.read_sql(db_names_query, engine)
+    db_names = []
+    for _, row in db_names_df.iterrows():
+        db_names.append(row["db"])
+
+    print(f"총 {len(db_names)}의 접근 가능한 모든 데이터베이스를 가져왔습니다.\n")
+
+    return db_names
+
+
+def embed_db_meta_data(db_names):
+    db_meta_data = {}
+    db_meta_data["accounting_db"] = (
+        "accounting_db는 주로 회계 및 환불 관련 트랜잭션, 통계 및 용어 정의를 관리하기 위해 설계된 데이터베이스입니다. 이 데이터베이스는 고객의 구매 및 환불 내역을 추적하고, 환불 비용을 관리하며, 회계 용어 및 정의를 저장하는 여러 테이블로 구성되어 있습니다. 데이터베이스의 주요 목적은 회계 데이터의 정확한 분석과 보고를 통해 재무 결정을 지원하는 것입니다."
+    )
+    db_meta_data["common_db"] = (
+        "common_db는 고객, 제품, 주문 및 주문 항목에 대한 정보를 관리하는 데이터베이스입니다. 이 데이터베이스는 전자상거래 환경에서 고객과 제품 간의 상호작용을 효율적으로 처리할 수 있도록 설계되었습니다."
+    )
+    db_meta_data["cs_db"] = (
+        "cs_db는 고객 서비스(CS) 관련 데이터를 저장하고 관리하기 위한 데이터베이스입니다. 이 데이터베이스는 주로 환불 요청, 통계, 용어 정의, 환불 처리 및 고객 만족도 데이터를 포함하여 고객 서비스 운영의 효율성을 높이고 고객 경험을 개선하는 데 기여합니다."
+    )
+
+    db_meta_texts = []
+    for db_name in db_names:
+        text = f"""DB name: {db_name}\nBusniss meta data: {db_meta_data[db_name]}"""
+        db_meta_texts.append(text)
+
+    print("벡터 데이터베이스(DB 메타 데이터) 생성 중...")
+    embeddings = OpenAIEmbeddings()
+    vector_store = FAISS.from_texts(db_meta_texts, embeddings)
+    print("벡터 데이터베이스(DB 메타 데이터) 생성 완료!\n")
+
+    return vector_store
+
+
+def embed_table_info(db_names, engine):
+    table_info_query = """SELECT
+    t.TABLE_SCHEMA AS 데이터베이스,
+    t.TABLE_NAME AS 테이블명,
+    GROUP_CONCAT(
+        CONCAT(
+            c.COLUMN_NAME, ' (',
+            c.COLUMN_TYPE,
+            CASE WHEN c.IS_NULLABLE = 'YES' THEN ', nullable' ELSE '' END,
+            CASE WHEN c.COLUMN_KEY = 'PRI' THEN ', primary key' ELSE '' END,
+            ')'
+            ) SEPARATOR '; '
+        ) AS 컬럼정보
+    FROM information_schema.TABLES t
+    JOIN information_schema.COLUMNS c
+        ON t.TABLE_SCHEMA = c.TABLE_SCHEMA
+        AND t.TABLE_NAME = c.TABLE_NAME
+    WHERE t.TABLE_SCHEMA NOT IN ('mysql', 'performance_schema', 'sys', 'information_schema')
+    GROUP BY t.TABLE_SCHEMA, t.TABLE_NAME;"""
+
+    print("모든 테이블 데이터를 가져오는 중...")
+    table_info_df = pd.read_sql(table_info_query, engine)
+    table_ddl_texts = []
+    available_dbs = set(db_names)
+    for _, row in table_info_df.iterrows():
+        db_name = row["데이터베이스"]
+        if db_name in available_dbs:
+            text = f"""데이터베이스: {db_name}\n테이블명: {row['테이블명']}\n컬럼정보: {row['컬럼정보']}"""
+            table_ddl_texts.append(text)
+    print(f"총 {len(table_ddl_texts)}개의 테이블 테이터 확보")
+
+    print("벡터 데이터베이스(테이블 데이터) 생성 중...")
+    embeddings = OpenAIEmbeddings()
+    vector_store = FAISS.from_texts(table_ddl_texts, embeddings)
+    print("벡터 데이터베이스(테이블 데이터) 생성 완료!\n")
+    return vector_store
+
+
+def get_table_ddl(db_name: str | None, DB_SERVER) -> Tuple[List[str], List[str]]:
+    if not db_name:
+        return None, None  # type: ignore
+    print(f"Get Table DDL data from {db_name}")
+    db_url = os.path.join(DB_SERVER, db_name)
+    engine = create_engine(db_url)
+    print("Engine Created!")
+    # DB 내 정보 확인
+    inspector = inspect(engine)
+    # DB 내 모든 테이블 이름 가져오기
+    all_tables = set(inspector.get_table_names() + inspector.get_view_names())
+    print("Table inspection Completed!")
+
+    # TODO
+    # 이 단계에서 사용자에 따라 접근 가능한 테이블을 반영은 할 수 있다.
+    # 다만, 이 함수가 chat model의 tool로서 쓰이지 않는다면 굳이 반영을 안해도 된다.
+    to_reflect = set(all_tables)
+    print(f"Tables to get DDL: {to_reflect}")
+    # 테이블의 메타데이터(컬럼 정보 등)를 저장하기 위한 객체 생성
+    meta_data = MetaData()
+    # 지정된 db 로부터 메타데이터 추출
+    if to_reflect:
+        meta_data.reflect(
+            views=True,
+            bind=engine,
+            only=list(to_reflect),
+            schema=None,
+        )
+    # 모든 테이블 중 to_reflect에 존재하는(확인하기로 한) 테이블만 추출
+    meta_tables = [tbl for tbl in meta_data.sorted_tables if tbl.name in to_reflect]
+    # 각 테이블의 메타데이터를 보고 테이블 DDL 정보를 작성
+    ddl_data, table_names = [], []
+    for table in meta_tables:
+        create_table = str(CreateTable(table).compile(engine))
+        table_info = f"{create_table.rstrip()}"
+        ddl_data.append(table_info)
+        table_names.append(table.name)
+    print(f"GETTING TABLE DDL from {db_name} has been completed!\n")
+    return table_names, ddl_data
+
+
+def embed_table_ddl(db_names, DB_SERVER):
+    table_ddl_texts = []
+    for db_name in db_names:
+        table_info, ddl_info = get_table_ddl(db_name, DB_SERVER)
+        for table_name, ddl in zip(table_info, ddl_info):
+            text = f"""데이터베이스: {db_name}\n테이블명: {table_name}\n테이블 DDL: {ddl}"""
+            table_ddl_texts.append(text)
+
+    print("벡터 데이터베이스(테이블 DDL) 생성 중...")
+    embeddings = OpenAIEmbeddings()
+    vector_store = FAISS.from_texts(table_ddl_texts, embeddings)
+    print("벡터 데이터베이스(테이블 DDL) 생성 완료!\n")
+    return vector_store
+
+
+def get_vector_stores() -> Dict[str, VectorStore]:
+    load_dotenv()
+    DB_SERVER = os.getenv("URL")
+    information_schema_path = os.path.join(DB_SERVER, "INFORMATION_SCHEMA")  # type: ignore
+    # create_engine으로 db에 접근 준비
+    engine = create_engine(information_schema_path)
+
+    vector_store_dict = {}
+    # 접근 가능한 DB 이름 얻기
+    db_names = get_db_names(engine)
+    vector_store_dict["db_meta_data"] = embed_db_meta_data(db_names)
+    vector_store_dict["table_info"] = embed_table_info(db_names, engine)
+    # 오래 걸리기에 Redis가 완성되면 ddl 데이터를 임베딩 하는 것으로 한다.
+    # vector_store_dict['table_ddl'] = embed_table_ddl(db_names, DB_SERVER)
+
+    return vector_store_dict

--- a/langgraph_/graph.py
+++ b/langgraph_/graph.py
@@ -2,7 +2,7 @@ from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.checkpoint.memory import MemorySaver
 
-from node import (
+from .node import (
     GraphState,
     question_evaluation,
     table_selection,

--- a/langgraph_/graph.py
+++ b/langgraph_/graph.py
@@ -5,16 +5,10 @@ from langgraph.checkpoint.memory import MemorySaver
 from node import (
     GraphState,
     question_evaluation,
-    embodying_and_extracting,
-    classify_question_category,
+    table_selection,
     non_sql_conversation,
-    crete_query,
-    explain_query,
-    explain_table,
-    correct_query_grammar,
-    guide_utilization,
     user_question_checker,
-    category_checker,
+    query_creation,
 )
 
 
@@ -23,37 +17,18 @@ def make_graph() -> CompiledStateGraph:
 
     workflow.add_node("질문 평가", question_evaluation)
     workflow.add_node("일반적인 대화", non_sql_conversation)
-    workflow.add_node("질문 구체화 및 정보 추출", embodying_and_extracting)
-
-    workflow.add_node("질문 카테고리 분류", classify_question_category)
-    workflow.add_node("crete_query", crete_query)
-    workflow.add_node("explain_query", explain_query)
-    workflow.add_node("explain_table", explain_table)
-    workflow.add_node("correct_query_grammar", correct_query_grammar)
-    workflow.add_node("guide_utilization", guide_utilization)
+    workflow.add_node("Table 선택", table_selection)
 
     workflow.add_conditional_edges(
         "질문 평가",  # 사용자의 질문이 데이터 및 비즈니스와 관련 되어있는지 평가
         user_question_checker,  # check로 평가 데이터를 추출한 뒤, 아래의 조건에 따라 다른 노드에 전달
         {
             "0": "일반적인 대화",
-            "1": "질문 구체화 및 정보 추출",
+            "1": "Table 선택",
         },
     )
 
-    workflow.add_edge("질문 구체화 및 정보 추출", "질문 카테고리 분류")
-
-    workflow.add_conditional_edges(
-        "질문 카테고리 분류",
-        category_checker,
-        {
-            "쿼리문 생성": "crete_query",
-            "쿼리문 해설": "explain_query",
-            "테이블 해설": "explain_table",
-            "쿼리문 문법 검증": "correct_query_grammar",
-            "테이블 및 컬럼 활용 안내": "guide_utilization",
-        },
-    )
+    workflow.add_node("SQL 쿼리문 생성", query_creation)
 
     # 시작점을 설정합니다.
     workflow.set_entry_point("질문 평가")

--- a/langgraph_/graph.py
+++ b/langgraph_/graph.py
@@ -30,6 +30,8 @@ def make_graph() -> CompiledStateGraph:
 
     workflow.add_node("SQL 쿼리문 생성", query_creation)
 
+    workflow.add_edge("Table 선택", "SQL 쿼리문 생성")
+
     # 시작점을 설정합니다.
     workflow.set_entry_point("질문 평가")
 

--- a/langgraph_/langgraph.sh
+++ b/langgraph_/langgraph.sh
@@ -2,4 +2,4 @@ python langgraph_main.py\
     --recursion-limit 50\
     --thread-id "TEST_RUN"\
     --model-name "gpt-4o-mini"\
-    --user-question "강호준이 최근 일주일간 몇캔의 닥터페퍼를 마셨는지 알려줘"
+    --user-question "common_db의 전체 주문 중 환불된 주문의 비율은 얼마인가요?"

--- a/langgraph_/langgraph_main.py
+++ b/langgraph_/langgraph_main.py
@@ -3,6 +3,7 @@ import argparse
 from node import GraphState
 from graph import make_graph
 from utils import get_runnable_config
+from faiss_init import get_vector_stores
 
 
 def get_config():
@@ -19,9 +20,11 @@ def get_config():
     # 추후에 진행 예정
     parser.add_argument("--model-name", default="gpt-4o-mini", type=str)
 
+    parser.add_argument("--context-cnt", default=10, type=int)
+
     parser.add_argument(
         "--user-question",
-        default="강호준이 최근 일주일간 몇캔의 닥터페퍼를 마셨는지 알려줘",
+        default="common_db의 전체 주문 중 환불된 주문의 비율은 얼마인가요?",
         type=str,
     )
 
@@ -41,7 +44,7 @@ if __name__ == "__main__":
     graph = make_graph()
 
     # 입력을 위해 그래프 상태 만들기
-    inputs = GraphState(user_question=config.user_question)  # type: ignore
+    inputs = GraphState(user_question=config.user_question, context_cnt=config.context_cnt)  # type: ignore
     outputs = graph.invoke(input=inputs, config=runnable_config)
 
-    print(outputs)
+    print(outputs["final_answer"])

--- a/langgraph_/langgraph_main.py
+++ b/langgraph_/langgraph_main.py
@@ -1,9 +1,9 @@
 import argparse
 
-from node import GraphState
-from graph import make_graph
-from utils import get_runnable_config
-from faiss_init import get_vector_stores
+from .node import GraphState
+from .graph import make_graph
+from .utils import get_runnable_config
+from .faiss_init import get_vector_stores
 
 
 def get_config():
@@ -31,6 +31,23 @@ def get_config():
     config = parser.parse_args()
 
     return config
+
+
+def text2sql(user_input):
+    # config 설정
+    config = get_config()
+    runnable_config = get_runnable_config(
+        recursion_limit=config.recursion_limit, thread_id=config.thread_id
+    )
+
+    # graph 생성
+    graph = make_graph()
+
+    # 입력을 위해 그래프 상태 만들기
+    inputs = GraphState(user_question=user_input, context_cnt=config.context_cnt)  # type: ignore
+    outputs = graph.invoke(input=inputs, config=runnable_config)
+
+    return outputs["final_answer"]
 
 
 if __name__ == "__main__":

--- a/langgraph_/node.py
+++ b/langgraph_/node.py
@@ -2,7 +2,7 @@ from langchain_core.vectorstores import VectorStore
 from langchain_community.vectorstores import FAISS
 
 from typing import TypedDict, List, Dict
-from task import (
+from .task import (
     evaluate_user_question,
     simple_conversation,
     select_relevant_tables,
@@ -11,7 +11,7 @@ from task import (
 )
 
 # FAISS 객체는 serializable 하지 않아 Graph State에 넣어 놓을 수 없다.
-from faiss_init import get_vector_stores
+from .faiss_init import get_vector_stores
 
 
 # GrpahState 정의

--- a/streamlit_langgraph.py
+++ b/streamlit_langgraph.py
@@ -1,0 +1,39 @@
+import streamlit as st
+from langchain_openai import ChatOpenAI
+from dotenv import load_dotenv
+from langgraph_.langgraph_main import text2sql
+
+
+load_dotenv()
+
+
+# GPT 모델 초기화
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+
+# 세션 상태 초기화
+if "conversation_history" not in st.session_state:
+    st.session_state.conversation_history = []
+
+# Streamlit UI
+st.title("GPT로 SQL 쿼리 생성기")
+user_input = st.text_input("데이터에 대해 질문하세요요:")
+
+
+if st.button("쿼리 생성 및 실행"):
+    response = text2sql(user_input)
+
+    # response의 전체 내용 확인 (디버깅 목적)
+    st.write("Response 전체 내용:")
+    st.write(response)
+
+    # 대화 기록에 추가
+    st.session_state.conversation_history.append(
+        {"question": user_input, "response": response}
+    )
+
+# 대화 기록 표시
+st.subheader("대화 기록")
+for entry in st.session_state.conversation_history:
+    st.write(f"질문: {entry['question']}")
+    st.write(f"Response 전체 내용: {entry['response']}")


### PR DESCRIPTION
### 제목
접근 가능한 모든 DB들의 정보를 이용한 Text2SQL

### 설명
사용자가 접근 가능한 모든 DB들의 테이블 및 컬럼 정보를 이용하여 사용자의 질문에 맞는 SQL문을 반환하는 workflow를 모듈화 하여 구현했습니다.

### 변경 내용
**faiss_init.py 추가**
```
streamlit_langgraph.py : 기존에 streamlit으로 서빙했던 SQL agent 대신 LangGraph를 연결하여 서빙해주는 모듈
langgraph
├── faiss_init.py : FAISS를 이용해 필요한 정보들을 벡터 DB에 임베딩 하는 모듈
├── graph.py : 정의된 노드들을 edge로 연결시켜 그래프를 만들어주는 모듈
├── langgraph.sh : langgraph_main.py를 테스트 해줄 수 있는 쉘 스크립트
├── langgraph_main.py : text 2 sql 과정을 실행시켜주는 모듈
├── node.py : 노드들이 정의되어 있는 모듈
├── task.py :  노드들의 세부 task들이 함수의 형태로 정의되어 있는 모듈
└── utils.py : config 정보들을 정의하는 모듈
```
### 테스트 방법
Streamlit 로컬 서빙 확인
```
streamlit run streamlit_langgraph.py
```
LangGraph만 확인
```
cd langgraph_
sh langgraph.sh
```
### 관련 이슈
LangGraph Workflow의 입력으로 사용되는 GraphState(Typed dict)에 FAISS 까지 담아서 invoke를 시도 했으나, FAISS는 serializable 하지 않아 불가능하다는 오류가 발생

- retrieve가 필요한 노드에서 FAISS를 불러오는 방식으로 대처
- Vector DB 서버(ex. Redis)를 만들어 놓은 뒤 필요한 정보들을 임베딩 하고, GraphState에 들어갈 입력으로는 Vector DB 서버 주소를 넣는 방식이 필요함  