### PR TITLE
model_merge

### DIFF
--- a/backend/langgraph.sh
+++ b/backend/langgraph.sh
@@ -2,6 +2,6 @@ python -m langgraph_.langgraph_main\
     --recursion-limit 50\
     --thread-id "TEST_RUN"\
     --model-name "gpt-4o-mini"\
-    --user-question "자동 처리된 환불의 평균 금액과 수동 처리된 환불의 평균 금액은 얼마나 차이나나요?"\
+    --user-question "전체 주문 중 환불된 주문의 비율은 얼마인가요?"\
     --max-query-fix 2\
     --sample-info 5

--- a/backend/langgraph_/node.py
+++ b/backend/langgraph_/node.py
@@ -132,7 +132,7 @@ def table_selection(state: GraphState) -> GraphState:
     Returns:
         GraphState: 검색된 context들과 검수를 통과한 context의 index list가 추가된 그래프 상태
     """
-    user_qusetion = state["user_question"]
+    user_question = state["user_question"]
     context_cnt = state["context_cnt"]
     flow_status = state.get("flow_status", "KEEP")
     sample_info = state["sample_info"]
@@ -142,7 +142,7 @@ def table_selection(state: GraphState) -> GraphState:
     # vector_store = state["vector_store_dict"]["table_info"] # table_ddl
     # 사용자 질문과 관련성이 있는 테이블+컬럼정보를 검색
     table_contexts = select_relevant_tables(
-        user_question=user_qusetion, context_cnt=context_cnt, vector_store=vector_store
+        user_question=user_question, context_cnt=context_cnt, vector_store=vector_store
     )
     # 검색된 context를 검수
     if flow_status == "RESELECT":
@@ -150,7 +150,7 @@ def table_selection(state: GraphState) -> GraphState:
         prev_query = state["sql_query"]
         error_msg = state["error_msg"]
         table_contexts_ids = extract_context(
-            user_question=user_qusetion,
+            user_question=user_question,
             table_contexts=table_contexts,
             flow_status=flow_status,
             prev_list=prev_list,
@@ -159,7 +159,7 @@ def table_selection(state: GraphState) -> GraphState:
         )
     else:
         table_contexts_ids = extract_context(
-            user_question=user_qusetion, table_contexts=table_contexts
+            user_question=user_question, table_contexts=table_contexts
         )
     return GraphState(
         table_contexts=table_contexts,
@@ -169,9 +169,17 @@ def table_selection(state: GraphState) -> GraphState:
 
 
 def query_creation(state: GraphState) -> GraphState:
-    user_qusetion = state["user_question"]
+    user_question = state["user_question"]
     table_contexts = state["table_contexts"]
     table_contexts_ids = state["table_contexts_ids"]
+
+    # 디버깅을 위한 타입 체크
+    print(f"Type of user_question in node.py: {type(user_question)}")
+    print(f"Value of user_question in node.py: {user_question}")
+    
+    # user_question이 문자열이 아닌 경우 문자열로 변환
+    if not isinstance(user_question, str):
+        user_question = str(user_question)    
 
     query_fix_cnt = state.get("query_fix_cnt")
     flow_status = state.get("flow_status", "KEEP")
@@ -181,7 +189,7 @@ def query_creation(state: GraphState) -> GraphState:
         error_msg = state["error_msg"]
         print("Do Query Fix!!!")
         sql_query = create_query(
-            user_qusetion,
+            user_question,
             table_contexts,
             table_contexts_ids,
             flow_status=flow_status,
@@ -190,7 +198,7 @@ def query_creation(state: GraphState) -> GraphState:
         )
 
     else:
-        sql_query = create_query(user_qusetion, table_contexts, table_contexts_ids)
+        sql_query = create_query(user_question, table_contexts, table_contexts_ids)
 
     return GraphState(
         sql_query=sql_query,

--- a/backend/langgraph_/task.py
+++ b/backend/langgraph_/task.py
@@ -8,10 +8,14 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.sql.expression import Executable
 from sqlalchemy.engine import Result
 
+from .utils import load_qwen_model, EmptyQueryResultError, NullQueryResultError, load_prompt
 from .utils import EmptyQueryResultError, NullQueryResultError, load_prompt
 from typing import List, Any, Union, Sequence, Dict
 from pydantic import BaseModel, Field
 import os, re
+
+from unsloth import FastLanguageModel 
+import torch 
 
 
 def evaluate_user_question(user_question: str) -> str:
@@ -322,50 +326,66 @@ def create_query(
     prev_query="",
     error_msg="",
 ):
-    output_parser = StrOutputParser()
-    context = ""
-    for idx, table_info in enumerate(table_contexts):
-        if idx in set(table_contexts_ids):
-            context += table_info + "\n\n"
-
-    prefix = load_prompt("prompts/query_creation/prefix_v1.prompt").format(
-        context=context
-    )
-
-    postfix = load_prompt("prompts/query_creation/postfix_v1.prompt")
-
-    if flow_status == "KEEP":
-        main_prompt = load_prompt("prompts/query_creation/generate_v1.prompt")
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                SystemMessage(content=prefix + main_prompt + postfix),
-                (
-                    "human",
-                    """user_question: {user_question}""",
-                ),
-            ]
-        )
-    else:
-        regen_prompt = load_prompt(
-            "prompts/query_creation/regenerate_v1.prompt"
-        ).format(prev_query=prev_query, result_msg=error_msg)
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                SystemMessage(content=prefix + regen_prompt + postfix),
-                ("human", """user_question: {user_question}"""),
-            ]
-        )
-
-    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
-    chain = prompt | llm | output_parser
-
-    output = chain.invoke({"user_question": user_question})
     try:
-        sql_query = re.search(r"```sql\s*(.*?)\s*```", output, re.DOTALL).group(1)
-    except:
-        sql_query = re.search(r"SELECT.*?;", output, re.DOTALL).group(1)
+        # 컨텍스트 생성
+        context = ""
+        for idx, table_info in enumerate(table_contexts):
+            if idx in set(table_contexts_ids):
+                context += table_info + "\n\n"
 
-    return sql_query
+        # 프롬프트 로드 및 구성
+        prefix = load_prompt("prompts/query_creation/prefix_v1.prompt").format(
+            context=context
+        )
+        postfix = load_prompt("prompts/query_creation/postfix_v1.prompt")
+
+        # flow_status에 따른 프롬프트 생성
+        if flow_status == "KEEP":
+            main_prompt = load_prompt("prompts/query_creation/generate_v1.prompt")
+            full_prompt = prefix + main_prompt + postfix + f"\n\nuser_question: {user_question}"
+        else:
+            regen_prompt = load_prompt(
+                "prompts/query_creation/regenerate_v1.prompt"
+            ).format(prev_query=prev_query, result_msg=error_msg)
+            full_prompt = prefix + regen_prompt + postfix + f"\n\nuser_question: {user_question}"
+
+        # Qwen 모델 로드 및 추론 준비
+        model, tokenizer = load_qwen_model()
+        model = FastLanguageModel.for_inference(model)  # 추론을 위한 모델 준비
+
+        # 입력 토크나이징
+        inputs = tokenizer(
+            full_prompt,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=2048
+        )
+
+        # 모델 추론
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=512,
+                pad_token_id=tokenizer.pad_token_id,
+                eos_token_id=tokenizer.eos_token_id
+            )
+
+        # 결과 디코딩 및 SQL 추출
+        output = tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+        try:
+            sql_query = re.search(r"```sql\s*(.*?)\s*```", output, re.DOTALL).group(1)
+        except:
+            sql_query = re.search(r"SELECT.*?;", output, re.DOTALL).group(0)
+
+        return sql_query.strip()
+
+    except Exception as e:
+        print("\n=== 에러 발생 ===")
+        print(f"에러 타입: {type(e)}")
+        print(f"에러 메시지: {str(e)}")
+        raise
 
 
 def check_query_result(result: Sequence[Dict[str, Any]]) -> Exception | None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Dict, Any
+from langgraph_.langgraph_main import text2sql
+
+app = FastAPI()
+
+class ChatRequest(BaseModel):
+    question: str
+
+class ChatResponse(BaseModel):
+    answer: str
+
+@app.post("/chating")
+async def chat_endpoint(request: ChatRequest) -> ChatResponse:
+    try:
+        # text2sql 함수 호출
+        result = text2sql(request.question)
+        
+        return ChatResponse(
+            answer=result['answer']
+        )
+    
+    except Exception as e:
+        return ChatResponse(
+            answer=f"죄송합니다. 오류가 발생했습니다: {str(e)}"
+        )
+
+# uvicorn main:app --reload로 실행

--- a/backend/test.py
+++ b/backend/test.py
@@ -1,0 +1,62 @@
+import torch
+from transformers import AutoTokenizer
+from unsloth import FastLanguageModel
+
+def test_qwen_model():
+    try:
+        print("=== Qwen 모델 테스트 시작 ===")
+        
+        # 모델 설정
+        model_name = "100suping/Qwen2.5-Coder-34B-Instruct-kosql-adapter"
+        huggingface_token = "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"
+        
+        print(f"모델 로딩 시작: {model_name}")
+        
+        # 모델과 토크나이저 로드
+        model, tokenizer = FastLanguageModel.from_pretrained(
+            model_name=model_name,
+           token=huggingface_token,
+            load_in_8bit=True
+        )
+        
+        print("모델과 토크나이저 로드 완료")
+        
+        # 테스트용 입력
+        test_input = "전체 주문 중 환불된 주문의 비율은 얼마인가요?"
+        print(f"\n테스트 입력: {test_input}")
+        
+        # 입력 토크나이징
+        inputs = tokenizer(test_input, return_tensors="pt")
+        print("토크나이징 완료")
+        
+        # 모델 추론
+        print("\n추론 시작...")
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=512,
+                pad_token_id=tokenizer.pad_token_id,
+                eos_token_id=tokenizer.eos_token_id
+            )
+        
+        # 결과 디코딩
+        result = tokenizer.decode(outputs[0], skip_special_tokens=True)
+        print("\n=== 결과 ===")
+        print(result)
+        
+        return True
+        
+    except Exception as e:
+        print("\n=== 에러 발생 ===")
+        print(f"에러 타입: {type(e)}")
+        print(f"에러 메시지: {str(e)}")
+        return False
+
+if __name__ == "__main__":
+    print("CUDA 사용 가능:", torch.cuda.is_available())
+    print("사용 가능한 GPU:", torch.cuda.device_count())
+    if torch.cuda.is_available():
+        print("현재 GPU:", torch.cuda.get_device_name(0))
+    
+    success = test_qwen_model()
+    print("\n테스트 결과:", "성공" if success else "실패")

--- a/backend/test2.py
+++ b/backend/test2.py
@@ -1,0 +1,72 @@
+import torch
+from transformers import AutoTokenizer
+from unsloth import FastLanguageModel
+from transformers import BitsAndBytesConfig
+
+def test_qwen_model():
+    try:
+        print("=== Qwen 모델 테스트 시작 ===")
+        
+        # 모델 설정
+        model_name = "100suping/Qwen2.5-Coder-34B-Instruct-kosql-adapter"
+        huggingface_token = "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"
+        
+        print(f"모델 로딩 시작: {model_name}")
+        
+        # 8비트 양자화 설정
+        bnb_config = BitsAndBytesConfig(
+            load_in_8bit=True,
+            bnb_4bit_compute_dtype=torch.float16
+        )
+        
+        # 모델과 토크나이저 로드
+        model, tokenizer = FastLanguageModel.from_pretrained(
+            model_name=model_name,
+            token=huggingface_token,
+            quantization_config=bnb_config
+        )
+        
+        # 추론을 위한 모델 준비 - 이 부분이 추가됨
+        model = FastLanguageModel.for_inference(model)
+        
+        print("모델과 토크나이저 로드 완료")
+        
+        # 테스트용 입력
+        test_input = "전체 주문 중 환불된 주문의 비율은 얼마인가요?"
+        print(f"\n테스트 입력: {test_input}")
+        
+        # 입력 토크나이징
+        inputs = tokenizer(test_input, return_tensors="pt")
+        print("토크나이징 완료")
+        
+        # 모델 추론
+        print("\n추론 시작...")
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=512,
+                pad_token_id=tokenizer.pad_token_id,
+                eos_token_id=tokenizer.eos_token_id
+            )
+        
+        # 결과 디코딩
+        result = tokenizer.decode(outputs[0], skip_special_tokens=True)
+        print("\n=== 결과 ===")
+        print(result)
+        
+        return True
+        
+    except Exception as e:
+        print("\n=== 에러 발생 ===")
+        print(f"에러 타입: {type(e)}")
+        print(f"에러 메시지: {str(e)}")
+        return False
+
+if __name__ == "__main__":
+    print("CUDA 사용 가능:", torch.cuda.is_available())
+    print("사용 가능한 GPU:", torch.cuda.device_count())
+    if torch.cuda.is_available():
+        print("현재 GPU:", torch.cuda.get_device_name(0))
+    
+    success = test_qwen_model()
+    print("\n테스트 결과:", "성공" if success else "실패")

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -1,0 +1,61 @@
+import streamlit as st
+import requests
+
+# FastAPI 서버의 엔드포인트 URL
+API_URL = "14.35.173.251:8000/chat"
+
+def main():
+    st.title("🤖 AI 텍스트-to-SQL 챗봇")
+    
+    # 세션 상태에 메시지 저장
+    if 'messages' not in st.session_state:
+        st.session_state.messages = []
+    
+    # 기존 메시지 표시
+    for message in st.session_state.messages:
+        with st.chat_message(message["role"]):
+            st.markdown(message["content"])
+            
+            # SQL 쿼리 있으면 추가 표시
+            if message.get("sql"):
+                with st.expander("생성된 SQL 쿼리"):
+                    st.code(message["sql"], language="sql")
+    
+    # 사용자 입력 처리
+    if prompt := st.chat_input("데이터베이스에 대해 무엇을 알고 싶으신가요?"):
+        # 사용자 메시지 추가
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        
+        # 사용자 메시지 표시
+        with st.chat_message("user"):
+            st.markdown(prompt)
+        
+        # 로딩 상태 표시
+        with st.chat_message("assistant"):
+            message_placeholder = st.empty()
+            message_placeholder.markdown("생각 중...")
+        
+        try:
+            # FastAPI 백엔드로 요청 보내기
+            response = requests.post(API_URL, json={"question": prompt})
+            result = response.json()
+            
+            # 응답 메시지 추가 및 표시
+            full_message = {
+                "role": "assistant", 
+                "content": result["answer"],
+                "sql": result.get("sql")  # SQL 쿼리 포함
+            }
+            st.session_state.messages.append(full_message)
+            message_placeholder.markdown(result["answer"])
+            
+            # SQL 쿼리 있으면 expander로 표시
+            if result.get("sql"):
+                with st.expander("생성된 SQL 쿼리"):
+                    st.code(result["sql"], language="sql")
+        
+        except requests.exceptions.RequestException as e:
+            message_placeholder.markdown(f"서버 연결 중 오류 발생: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### 제목
Model merge를 위한 요청 입니다. 

### 설명
우리의 qwen 모델을 연결하기 위한 부분입니다. 

### 변경 내용
바꾼 파일은 task.py, uitls.py, node.py(오탈자) 의 일부분 입니다. 
특히 task에서 create_query 부분에서 모델 연결 부분을 수정 하였으며 
utils에서는 모델을 불러오기 위한 부분 load_qwen_model 부분을 넣었습니다. 

### 테스트 방법
test1, test2 통해서 모델제대로 불러올수 있는지 확인하였고 
backend 내에서 bash 통해서 검증 하였습니다. 

`licer@c87c987cf282:~/sql-helper_default/backend$ bash langgraph.sh
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
🦥 Unsloth Zoo will now patch everything to make training faster!
접근 가능한 모든 데이터베이스를 가져오는 중...
총 3의 접근 가능한 모든 데이터베이스를 가져왔습니다.

총 14개의 데이터 확보
벡터 데이터베이스 생성 중...
벡터 데이터베이스 생성 완료!

Type of user_question in node.py: <class 'str'>
Value of user_question in node.py: 전체 주문 중 환불된 주문의 비율은 얼마인가요?
==((====))==  Unsloth 2024.11.11: Fast Qwen2 patching. Transformers:4.46.3.
   \\   /|    GPU: NVIDIA A100 80GB PCIe. Max memory: 79.325 GB. Platform: Linux.
O^O/ \_/ \    Torch: 2.5.1+cu124. CUDA: 8.0. CUDA Toolkit: 12.4. Triton: 3.1.0
\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.28.post3. FA2 = False]
 "-____-"     Free Apache license: http://github.com/unslothai/unsloth
Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
Loading checkpoint shards: 100%|████████████████████████████████████████████████████| 4/4 [00:04<00:00,  1.03s/it]
주어진 데이터에서 환불 요청 수(total_refund_requests)와 완료된 환불 수(completed_refunds)를 통해 전체 주문 중 환불된 주문의 비율을 계산할 수 있습니다. 

환불 비율은 다음과 같이 계산됩니다:

1. 전체 환불 요청 수(total_refund_requests)를 모두 더합니다.
2. 전체 완료된 환불 수(completed_refunds)를 모두 더합니다.
3. 환불 비율 = (전체 완료된 환불 수 / 전체 환불 요청 수) * 100

데이터를 가지고 이 계산을 해보면:

- 전체 환불 요청 수: 5 + 4 + 6 + 5 + 7 + 399 + 461 + 176 + 154 + 353 + 279 + 370 + 497 + 209 + 316 + 387 = 2,899
- 전체 완료된 환불 수: 3 + 4 + 5 + 4 + 6 + 42 + 236 + 164 + 132 + 222 + 248 + 264 + 151 + 93 + 211 + 316 = 1,810

환불 비율 = (1,810 / 2,899) * 100 ≈ 62.3%

따라서 전체 주문 중 환불된 주문의 비율은 약 62.3%입니다.`

확인완료 


### 관련 이슈
관련 이슈 특이사항은 없습니다. 