### PR TITLE
FEAT: CPU-only workflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "remote.autoForwardPortsFallback": 0
+}

--- a/backend/backend_cpu_env_setup.sh
+++ b/backend/backend_cpu_env_setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install -r requirements.txt
+pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu

--- a/backend/langgraph_/faiss_init.py
+++ b/backend/langgraph_/faiss_init.py
@@ -7,7 +7,6 @@ from langchain_openai import OpenAIEmbeddings
 from langchain_community.utilities import SQLDatabase
 
 from sqlalchemy import create_engine, inspect, MetaData
-from dotenv import load_dotenv
 from sqlalchemy.schema import CreateTable
 
 
@@ -177,7 +176,6 @@ def embed_db_info(db_names: str | None, DB_SERVER: str, sample_info: int):
 
 
 def get_vector_stores(sample_info: int) -> Dict[str, VectorStore]:
-    load_dotenv()
     DB_SERVER = os.getenv("URL")
     information_schema_path = os.path.join(DB_SERVER, "INFORMATION_SCHEMA")  # type: ignore
     # create_engine으로 db에 접근 준비

--- a/backend/langgraph_/node.py
+++ b/backend/langgraph_/node.py
@@ -22,6 +22,7 @@ from .faiss_init import get_vector_stores
 class GraphState(TypedDict):
     # Warning!
     # 그래프 내에서 사용될 모든 key값을 정의해야 오류가 나지 않는다.
+    llm_api: str  # Local, ChatGPT-4o
     user_question: str  # 사용자의 질문
     user_question_eval: str  # 사용자의 질문이 SQL 관련 질문인지 여부
     user_question_analyze: str  # 사용자 질문 분석
@@ -183,6 +184,7 @@ def query_creation(state: GraphState) -> GraphState:
     user_question = state["user_question"]
     table_contexts = state["table_contexts"]
     table_contexts_ids = state["table_contexts_ids"]
+    llm_api = state["llm_api"]
 
     query_fix_cnt = state.get("query_fix_cnt")
     flow_status = state.get("flow_status", "KEEP")
@@ -195,13 +197,16 @@ def query_creation(state: GraphState) -> GraphState:
             user_question,
             table_contexts,
             table_contexts_ids,
+            llm_api,
             flow_status=flow_status,
             prev_query=prev_query,
             error_msg=error_msg,
         )
 
     else:
-        sql_query = create_query(user_question, table_contexts, table_contexts_ids)
+        sql_query = create_query(
+            user_question, table_contexts, table_contexts_ids, llm_api
+        )
 
     return GraphState(
         sql_query=sql_query,

--- a/backend/langgraph_/task.py
+++ b/backend/langgraph_/task.py
@@ -25,6 +25,7 @@ import torch
 
 if torch.cuda.is_available():
     model, tokenizer = load_qwen_model()
+    print("Local Model is ready!")
 else:
     print("Non-GPU env has detected.")
 
@@ -265,6 +266,7 @@ def create_query(
     user_question,
     table_contexts,
     table_contexts_ids,
+    llm_api,
     flow_status="KEEP",
     prev_query="",
     error_msg="",
@@ -292,7 +294,8 @@ def create_query(
             ).format(prev_query=prev_query, result_msg=error_msg)
             system_prompt = prefix + regen_prompt + postfix
 
-        if torch.cuda.is_available():
+        # GPU를 사용 가능하며, 사용자가 로컬 LLM 사용을 원할 경우
+        if torch.cuda.is_available() and llm_api == "Local":
             full_prompt = system_prompt + f"\n\nuser_question: {user_question}"
             # 입력 토크나이징
             inputs = tokenizer(

--- a/backend/langgraph_/utils.py
+++ b/backend/langgraph_/utils.py
@@ -1,10 +1,8 @@
 from langchain_core.runnables import RunnableConfig
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers import BitsAndBytesConfig
-from unsloth import FastLanguageModel
 from huggingface_hub import login
 import argparse
-from dotenv import load_dotenv
 import os
 
 
@@ -69,9 +67,10 @@ def str2bool(v):
 
 
 def load_qwen_model():
+    from unsloth import FastLanguageModel
+
     global model, tokenizer
     # Hugging Face 토큰 설정
-    load_dotenv()
 
     # 환경 변수에서 Hugging Face 토큰 가져오기
     huggingface_token = os.getenv("HUGGINGFACE_TOKEN")

--- a/backend/langgraph_/utils.py
+++ b/backend/langgraph_/utils.py
@@ -3,7 +3,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers import BitsAndBytesConfig
 from huggingface_hub import login
 import argparse
-import os
+import os, re
 
 
 def get_runnable_config(recursion_limit: int, thread_id: str) -> RunnableConfig:
@@ -98,3 +98,15 @@ def load_qwen_model():
     model = FastLanguageModel.for_inference(model)
 
     return model, tokenizer
+
+
+def extract_context_tables(table_contexts, table_contexts_ids):
+    context_table_list = []
+    if not table_contexts_ids:
+        return []
+    table_pattern = r"CREATE TABLE\s+(.+?)\s*\("
+    for idx in table_contexts_ids:
+        table_name = re.findall(table_pattern, table_contexts[idx])[-1]
+        context_table_list.append(table_name.strip("`"))
+
+    return context_table_list

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,13 +18,13 @@ class LLMWorkflowInput(BaseModel):
     initial_question: int
     thread_id: str
     last_snapshot_values: dict | None
+    llm_api: str
 
 
 @app.post("/llm_workflow")
 def llm_workflow(workflow_input: LLMWorkflowInput):
     global workflow
     processed_input = workflow_input.model_dump()
-
     config = get_runnable_config(30, processed_input["thread_id"])
     inputs = {
         "user_question": processed_input["user_question"],
@@ -32,6 +32,7 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
         "max_query_fix": 2,
         "query_fix_cnt": -1,
         "sample_info": 5,
+        "llm_api": processed_input["llm_api"],
     }
     # 초기 질문이 아닌 경우
     if processed_input["initial_question"] == 0:
@@ -39,6 +40,7 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
         values["collected_questions"][
             -1
         ] += f"\n답변: {processed_input['user_question']}"
+        values["llm_api"] = processed_input["llm_api"]
         workflow.update_state(
             config,
             values,

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 import uvicorn
 
 from langgraph_.graph import make_graph, multiturn_test, make_graph_for_test
-from langgraph_.utils import get_runnable_config
+from langgraph_.utils import get_runnable_config, extract_context_tables
 from dotenv import load_dotenv
 
 app = FastAPI()
@@ -60,7 +60,14 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
             config=config,
             interrupt_before=["human_feedback"],
         )
-    print(outputs)
+    # print(outputs)
+    if "final_answer" in outputs and outputs["user_question_eval"]:
+        print(
+            "RAG과정에서 사용된 context table:",
+            extract_context_tables(
+                outputs["table_contexts"], outputs["table_contexts_ids"]
+            ),
+        )
     return outputs
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,8 +6,6 @@ from langgraph_.graph import make_graph, multiturn_test, make_graph_for_test
 from langgraph_.utils import get_runnable_config
 from dotenv import load_dotenv
 
-load_dotenv()
-
 app = FastAPI()
 
 # make_graph: 전체 과정, make_graph_for_test: 질문 구체화 생략, multiturn_test: 질문 구체화만 진행
@@ -65,4 +63,5 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
 
 
 if __name__ == "__main__":
+    load_dotenv(override=True)
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=False)

--- a/frontend/app2.py
+++ b/frontend/app2.py
@@ -193,7 +193,7 @@ def register_user(username, password, department, role):
             conn.close()
 
 
-def process_chat(prompt):
+def process_chat(prompt, llm_api):
     st.chat_message("user").write(prompt)
     st.session_state.conversation_history.append({"role": "user", "content": prompt})
 
@@ -216,6 +216,7 @@ def process_chat(prompt):
                 "initial_question": st.session_state.initial_question,
                 "thread_id": st.session_state.thread_id,
                 "last_snapshot_values": st.session_state.snapshot_values,
+                "llm_api": llm_api,
             },
         )
 
@@ -316,13 +317,23 @@ def main():
                     del st.session_state[key]
                 st.rerun()
 
+        with st.sidebar:
+            llm_api = st.radio(
+                "Which LLM would like you use?",
+                ["Local", "ChatGPT-4o"],
+                captions=[
+                    "unsloth/qwen2.5-34B-Coder-bnb-4bit",
+                    "OpenAI",
+                ],
+            )
+
         st.markdown('<div class="chat-container">', unsafe_allow_html=True)
         for message in st.session_state.conversation_history:
             st.chat_message(message["role"]).write(message["content"])
         st.markdown("</div>", unsafe_allow_html=True)
 
         if prompt := st.chat_input("데이터에 대해 질문하세요"):
-            process_chat(prompt)
+            process_chat(prompt, llm_api)
 
         if st.session_state.loading:
             with st.spinner("응답을 기다리는 중입니다..."):

--- a/frontend/app2.py
+++ b/frontend/app2.py
@@ -197,16 +197,16 @@ def process_chat(prompt):
     st.chat_message("user").write(prompt)
     st.session_state.conversation_history.append({"role": "user", "content": prompt})
 
-    if not check_department_access(st.session_state.user["department"], prompt):
-        error_message = (
-            "접근 권한이 없습니다. 해당 부서 관련 데이터만 조회할 수 있습니다."
-        )
-        st.error(error_message)
-        st.chat_message("assistant").write(error_message)
-        st.session_state.conversation_history.append(
-            {"role": "assistant", "content": error_message}
-        )
-        return
+    # if not check_department_access(st.session_state.user["department"], prompt):
+    #     error_message = (
+    #         "접근 권한이 없습니다. 해당 부서 관련 데이터만 조회할 수 있습니다."
+    #     )
+    #     st.error(error_message)
+    #     st.chat_message("assistant").write(error_message)
+    #     st.session_state.conversation_history.append(
+    #         {"role": "assistant", "content": error_message}
+    #     )
+    #     return
 
     try:
         response = requests.post(

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -2,3 +2,5 @@ streamlit>=1.40.1, <2
 requests>=2.27, <3
 pydantic>=2.10.1, <3
 python-dotenv>=1.0.0, <2
+mysql-connector-python
+bcrypt


### PR DESCRIPTION
### 제목
FEAT: CPU-only workflow

### 설명
cpu만을 이용해서 LLM workflow를 이용할 수 있도록 설계 했습니다.
torch.cuda.is_available()을 이용해서 gpu를 이용가능한지 확인 후, 이용 불가하면 cpu workflow로 진행됩니다.

### 변경 내용
1. cpu only backend 환경 세팅용 shell 스크립트 생성
2. task.py의 create_query에 cpu workflow 추가
3. frontend requirements.txt에 필요 라이브러리 추가
4. frontend 접근 권한 비활성화
5. 사용자가 어떤 LLM을 사용할지 선택할 수 있도록 기능 추가
6. 백엔드 터미널에서 workflow 내부 RAG 과정에서 어떤 테이블을 context로 사용했는지 출력하도록 기능 추가

![사용자가 사용하고 싶은 모델 선택 가능](https://github.com/user-attachments/assets/295d308a-6208-43ca-b803-53b2c8d848ab)


### 테스트 방법
기존과 동일

### 관련 이슈
