### PR TITLE
Feat: Logging in Local File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 
 chinook.*
+backend/logs

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,10 @@ class LLMWorkflowInput(BaseModel):
     llm_api: str
 
 
+class UserFeedbackInput(BaseModel):
+    user_feedback: int  # 좋아요 1, 싫어요 0
+
+
 @app.post("/llm_workflow")
 def llm_workflow(workflow_input: LLMWorkflowInput):
     global workflow
@@ -61,7 +65,7 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
             interrupt_before=["human_feedback"],
         )
     # print(outputs)
-    if "final_answer" in outputs and outputs["user_question_eval"]:
+    if "final_answer" in outputs and outputs["user_question_eval"] == 1:
         print(
             "RAG과정에서 사용된 context table:",
             extract_context_tables(
@@ -69,6 +73,12 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
             ),
         )
     return outputs
+
+
+@app.post("/user_feedback")
+def user_feedback(feedback_input: UserFeedbackInput):
+    processed_input = feedback_input.model_dump()
+    print(processed_input)
 
 
 if __name__ == "__main__":

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,11 @@ from pydantic import BaseModel
 import uvicorn
 
 from langgraph_.graph import make_graph, multiturn_test, make_graph_for_test
-from langgraph_.utils import get_runnable_config, extract_context_tables
+from langgraph_.utils import (
+    get_runnable_config,
+    extract_context_tables,
+    save_conversation,
+)
 from dotenv import load_dotenv
 
 app = FastAPI()
@@ -22,7 +26,8 @@ class LLMWorkflowInput(BaseModel):
 
 
 class UserFeedbackInput(BaseModel):
-    user_feedback: int  # 좋아요 1, 싫어요 0
+    user_feedback: int  # 좋아요 1-chosen, 싫어요 0-rejected
+    thread_id: str
 
 
 @app.post("/llm_workflow")
@@ -65,7 +70,7 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
             interrupt_before=["human_feedback"],
         )
     # print(outputs)
-    if "final_answer" in outputs and outputs["user_question_eval"] == 1:
+    if "final_answer" in outputs and outputs["user_question_eval"] == "1":
         print(
             "RAG과정에서 사용된 context table:",
             extract_context_tables(
@@ -78,7 +83,11 @@ def llm_workflow(workflow_input: LLMWorkflowInput):
 @app.post("/user_feedback")
 def user_feedback(feedback_input: UserFeedbackInput):
     processed_input = feedback_input.model_dump()
-    print(processed_input)
+    feedback = processed_input["user_feedback"]
+    config = get_runnable_config(30, processed_input["thread_id"])
+    snapshot = list(workflow.get_state_history(config))[0].values
+
+    save_conversation(snapshot, feedback)
 
 
 if __name__ == "__main__":

--- a/backend/main.py
+++ b/backend/main.py
@@ -87,7 +87,10 @@ def user_feedback(feedback_input: UserFeedbackInput):
     config = get_runnable_config(30, processed_input["thread_id"])
     snapshot = list(workflow.get_state_history(config))[0].values
 
-    save_conversation(snapshot, feedback)
+    if snapshot["user_question_eval"] == "1":
+        save_conversation(snapshot, feedback)
+    else:
+        print("simple conversation would not be saved.")
 
 
 if __name__ == "__main__":

--- a/frontend/app2.py
+++ b/frontend/app2.py
@@ -261,7 +261,10 @@ def process_chat(prompt, llm_api):
 def send_feedback(feedback):
     requests.post(
         f"http://{os.getenv('BACKEND_HOST')}:8000/user_feedback",
-        json={"user_feedback": feedback},
+        json={
+            "user_feedback": feedback,
+            "thread_id": st.session_state.thread_id,
+        },
     )
     st.session_state.is_end = 0
 
@@ -352,7 +355,7 @@ def main():
         if st.session_state.is_end:
             # 좋아요&싫어요 선택
             feedback = st.feedback("thumbs")
-            if feedback:
+            if feedback is not None:
                 # 백엔드 서버에 피드백 전달
                 send_feedback(feedback)
                 st.rerun()


### PR DESCRIPTION
### 제목
Local Logging 기능 추가

### 설명
최종 답변에 대해서 사용자가 피드백을 주면, 해당 피드백과 함께 LangGraph workflow내 상태 중 원하는 정보와 함께 csv 파일로 저장하는 기능을 추가했습니다.
일상 대화는 피드백을 받더라도 저장하지 않도록 했습니다. 

### 변경 내용

**frontend/app2.py** : 최종 답변이 출력된 후, 사용자의 피드백을 받아 백엔드 서버에 전달하는 기능 추가 

**backend/main.py** : /user_feedback이라는 새로운 API 엔드포인트를 생성, user_feedback에서 post 요청을 받으면, 사용자의 thread_id를 기반으로 피드백과 함께 저장

**backend/langgraph_/utils.py** : backend 디렉토리 내에 로그가 저장될 logs 디렉토리와 csv 파일을 생성 및 원하는 정보를 저장하는 함수를 추가

**.gitignore** : backend/logs를 추적하지 않도록 설정

### 테스트 방법

기존과 동일하게 진행하여, 최종 답변 아래에 뜨는 👍 👎  표시를 한번 누르면 backend/logs에 날짜별로 csv파일이 생성되어 저장됨

### 관련 이슈

기존에 일상대화를 진행 시, 오류가 났으나 이 브랜치에서 해결함