### PR TITLE
Feat: Model server has been built

### DIFF
--- a/backend/langgraph_/utils.py
+++ b/backend/langgraph_/utils.py
@@ -125,15 +125,15 @@ def save_conversation(snapshot, feedback):
         mode = "w"
     # CSV 파일 생성
     with open(csv_filename, mode=mode, newline="", encoding="utf-8") as csvfile:
-        writer = csv.writer(csvfile)
+        writer = csv.writer(csvfile, delimiter=",", quotechar='"')
         # 첫 작성 시 헤더 작성
         if mode == "w":
             writer.writerow(
                 [
                     "user_question",
                     "collected_questions",
-                    "table_contexts",
-                    "table_contexts_ids",
+                    # "table_contexts",
+                    # "table_contexts_ids",
                     "table_names",
                     "query_result",
                     "final_answer",

--- a/model/main.py
+++ b/model/main.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn, os
+from dotenv import load_dotenv
+
+from utils import initialize_model, do_text2sql
+
+
+load_dotenv(override=True)
+hf_llm = initialize_model()
+
+app = FastAPI()
+
+
+class LLMInput(BaseModel):
+    input_dict: dict
+    system_prompt: str
+    human_prompt: str
+
+
+@app.post("/qwen")
+def qwen(model_input: LLMInput):
+    processed_input = model_input.model_dump()
+    input_dict = processed_input["input_dict"]
+    system_prompt = processed_input["system_prompt"]
+    human_prompt = processed_input["human_prompt"]
+
+    response = do_text2sql(system_prompt, human_prompt, input_dict, hf_llm)
+    print("Text2SQL Done.")
+    print(response)
+    return {"response": response}

--- a/model/main.sh
+++ b/model/main.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+uvicorn main:app --host "0.0.0.0" --port 8001

--- a/model/model_server_setting.sh
+++ b/model/model_server_setting.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install -r requirements.txt
+pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+pip install --upgrade pip && pip install unsloth && echo "Backend setup complete!"

--- a/model/requirements.txt
+++ b/model/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pydantic
+python-dotenv
+transformers

--- a/model/utils.py
+++ b/model/utils.py
@@ -1,0 +1,71 @@
+from unsloth import FastLanguageModel
+from langchain_huggingface.llms import HuggingFacePipeline
+from transformers import pipeline, BitsAndBytesConfig
+from huggingface_hub import login
+
+from langchain_core.messages import SystemMessage, HumanMessage
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+import os
+
+
+def initialize_model():
+    # 환경 변수에서 Hugging Face 토큰 가져오기
+    huggingface_token = os.getenv("HUGGINGFACE_TOKEN")
+    login(token=huggingface_token)
+
+    # 모델 이름 설정
+    model_name = "unsloth/Qwen2.5-Coder-32B-Instruct"
+
+    # 8비트 양자화 설정
+    bnb_config = BitsAndBytesConfig(load_in_8bit=True)
+
+    home_path = os.path.expanduser("~")
+    cache_dir = os.path.join(home_path, "sql-helper/.cache/unsloth")
+
+    # FastLanguageModel을 사용하여 모델과 토크나이저 로드
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=model_name,
+        token=huggingface_token,
+        quantization_config=bnb_config,
+        cache_dir=cache_dir,
+        device_map="auto",
+    )
+
+    adapter_path = "100suping/Qwen2.5-Coder-34B-Instruct-kosql-adapter"
+    adapter_revision = "checkpoint-200"
+    model.load_adapter(
+        adapter_path,
+        revision=adapter_revision,
+    )
+    print("Adapter is loaded!")
+
+    # Unsloth 사용 시 inference 모드 전환
+    model = FastLanguageModel.for_inference(model)
+    print("Inference mode activated!")
+
+    # return model, tokenizer
+    pipe = pipeline(
+        "text-generation", model=model, tokenizer=tokenizer, max_new_tokens=512
+    )
+    hf_llm = HuggingFacePipeline(pipeline=pipe)
+    print("HuggingFacePipeline is ready!")
+
+    return hf_llm
+
+
+def do_text2sql(system_prompt, human_prompt, input_dict, hf_llm):
+    output_parser = StrOutputParser()
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            SystemMessage(content=system_prompt),
+            ("human", human_prompt),
+        ]
+    )
+
+    chain = prompt | hf_llm | output_parser
+
+    output = chain.invoke(input_dict)
+    response = output.split(human_prompt.format(**input_dict))[-1]
+    return response


### PR DESCRIPTION
### 제목
모델 서버 생성

### 설명
우리가 만든 로컬 모델을 백엔드 서버로부터 따로 분리해서 서빙하도록 만들었습니다.
GCP VM L4에서 어댑터를 불러와서 Text2SQL inference가 가능한 것까지 확인 했습니다.
어댑터의 revision은 model 디렉터리의 utils.py에서 알아서 설정하시면 됩니다.
모델 서버의 포트 번호는 현재 8001로 설정 되어 있습니다.

### 변경 내용
backend/langgraph_/task.py : 더 이상 모델을 불러오지 않으며, create_query 함수 내부에서 inference를 진행 하지 않고 모델 서버의 /qwen 에게 post 요청을 보내는 식으로 바뀜
```
sql-helper/
│
├── frontend/
│
├── backend/
│
├── model/
│   ├── main.py : post 요청을 받아서 로컬 LLM(Qwen)으로 Text2SQL을 진행할 API 엔드 포인트가 지정된 파일 
│   ├── main.sh : uvicorn 명령어로 main.py를 실행시키는 쉘 스크립트
│   ├── model_server_setting.sh : 모델 서버를 구동하는데 필요한 명령어들을 실행시키는 쉘 스크립트
│   ├── README.md
│   ├── requirements.txt : 가상환경에 설치할 라이브러리들이 담긴 파일
│   └── utils.py : 모델 불러오는 함수 및 TEXT2SQL 진행하는 함수 존재
│
├── .gitignore
└──README.md
```

### 테스트 방법
```
cd sql-helper/model
bash main.sh
```

### 관련 이슈
